### PR TITLE
docs(README): update example to current [[agents]] schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- README agentd configuration example now uses the current `[[agents]]` schema
+  with structured command argv.
+
 ## [0.1.0] — 2026-04-13
 
 Reference container image for agentd agent sessions. Wolfi-based, multi-stage

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ graphs.
 
 **Agent runtime:** [Claude Code](https://claude.ai/code) via the native
 installer. Authenticate headlessly by injecting `ANTHROPIC_API_KEY` as a
-credential in your agentd profile configuration.
+credential in your agentd agent configuration.
 
 ## Building
 
@@ -38,31 +38,19 @@ podman build --build-arg RUNA_REF=v0.1.0 -t tesserine/base .
 
 ## Using with agentd
 
-Reference this image in your profile configuration:
+Reference this image in your agent configuration:
 
 ```toml
-[[profiles]]
+[[agents]]
 name = "site-builder"
 base_image = "localhost/tesserine/base"
 methodology_dir = "../groundwork"
 repo = "https://github.com/your-org/your-project.git"
-command = [
-  "/bin/sh",
-  "-lc",
-  '''
-runa init --methodology /agentd/methodology/manifest.toml
-cat > .runa/config.toml <<'EOF'
-[agent]
-command = ["claude", "-p", "--dangerously-skip-permissions"]
-EOF
-if [ -n "${AGENTD_WORK_UNIT:-}" ]; then
-  exec runa run --work-unit "${AGENTD_WORK_UNIT}"
-fi
-exec runa run
-''',
-]
 
-[[profiles.credentials]]
+[agents.command]
+argv = ["claude", "-p", "--dangerously-skip-permissions"]
+
+[[agents.credentials]]
 name = "ANTHROPIC_API_KEY"
 source = "AGENTD_ANTHROPIC_KEY"
 ```


### PR DESCRIPTION
## Summary

- Updates the base README example to use agentd's current `[[agents]]` schema.
- Replaces the stale shell-wrapper command with structured `[agents.command].argv`.
- Preserves `base_image = "localhost/tesserine/base"` so the example still teaches the local base image convention.

## Changes

- README usage now refers to agent configuration instead of profile configuration.
- README TOML now uses `[[agents]]`, `[agents.command]`, and `[[agents.credentials]]`.
- CHANGELOG records the user-visible documentation correction under `[Unreleased]`.

## GitHub Issue(s)

Closes #1

## Test plan

- `rg -n "profiles|\\[\\[profiles\\]\\]|profiles\\.credentials|\\.runa/config|runa init|runa run" README.md CHANGELOG.md` returned no stale-schema matches.
- `rg -n "base_image = \\"localhost/tesserine/base\\"|\\[\\[agents\\]\\]|\\[agents\\.command\\]|argv = \\[\\"claude\\", \\"-p\\", \\"--dangerously-skip-permissions\\"\\]|\\[\\[agents\\.credentials\\]\\]" README.md` found the expected current-schema lines.
- `git diff --check`
- `(cd /home/pentaxis93/src/agentd && cargo test -p agentd parses_agents_with_declarative_command_argv)`

## Documentation coverage

- Updated: `README.md`, `CHANGELOG.md`.
- Verified not applicable: architecture/API documentation, because no runtime behavior or interface changed.
