### PR TITLE
fix(build): use Wolfi Rust for runa builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - README agentd configuration example now uses the current `[[agents]]` schema
   with structured command argv.
+- runa builder stage now uses Wolfi's packaged Rust toolchain instead of
+  installing a floating rustup stable toolchain during image builds.
 
 ## [0.1.0] — 2026-04-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,12 @@
 # ---------------------------------------------------------------------------
 FROM cgr.dev/chainguard/wolfi-base AS runa-builder
 
-RUN apk add --no-cache curl gcc git glibc-dev
-
-# Install Rust via rustup (Wolfi does not package cargo, and we need >= 1.85
-# for edition 2024)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-        sh -s -- -y --default-toolchain stable --profile minimal
-ENV PATH="/root/.cargo/bin:${PATH}"
+RUN apk add --no-cache \
+        curl \
+        gcc \
+        git \
+        glibc-dev \
+        rust-1.89
 
 ARG RUNA_REF=v0.1.0
 RUN git clone --depth 1 --branch "${RUNA_REF}" \


### PR DESCRIPTION
## Summary

- Uses Wolfi's packaged `rust-1.89` toolchain for the runa builder stage instead of installing Rust through rustup.
- Removes the floating rustup stable channel and the rustup PATH dependency from the Dockerfile.
- Records the build-substrate change in the unreleased changelog.

## Changes

- Builder stage installs `curl`, `gcc`, `git`, `glibc-dev`, and `rust-1.89` through `apk add --no-cache`.
- Rust toolchain ownership returns to Wolfi's package surface, where `rust-1.89` provides both `rustc` and `cargo`.
- Changelog explains the switch away from a floating rustup install.

## GitHub Issue(s)

Refs #4
Refs #5 for the unrelated Claude installer layer that blocked full final-image verification.

## Test plan

- `git diff --check`
- RED contract checks before implementation confirmed the old Dockerfile lacked `rust-1.89`, still referenced rustup, and lacked the changelog entry.
- Post-change contract checks confirmed `rust-1.89` is present, rustup references are absent, and the changelog entry exists.
- `podman build --target runa-builder --tag localhost/tesserine/base-runa-builder .`
- `podman run --rm localhost/tesserine/base-runa-builder rustc --version`
- `podman run --rm localhost/tesserine/base-runa-builder cargo --version`
- `podman run --rm localhost/tesserine/base-runa-builder /build/runa-bin --version`
- `podman run --rm localhost/tesserine/base-runa-builder /build/runa-mcp-bin --help`

Full `podman build --tag localhost/tesserine/base .` reached and completed the runa builder stage, then stayed active in the preexisting Claude Code native installer layer for more than 20 minutes. That separate final-stage build issue is tracked as #5.
