### PR TITLE
fix(build): bound Claude Code release install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - README agentd configuration example now uses the current `[[agents]]` schema
   with structured command argv.
+- Claude Code installation now uses a pinned Anthropic release binary verified
+  through the signed release manifest instead of the opaque latest installer.
 - runa builder stage now uses Wolfi's packaged Rust toolchain instead of
   installing a floating rustup stable toolchain during image builds.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # Ships with:
 #   runa       — cognitive runtime CLI (built from source)
 #   runa-mcp   — MCP server for agent communication (built from source)
-#   claude     — Claude Code CLI (Anthropic native installer)
+#   claude     — Claude Code CLI (pinned Anthropic release binary)
 
 # ---------------------------------------------------------------------------
 # Stage 1: Build runa from source
@@ -33,7 +33,71 @@ RUN git clone --depth 1 --branch "${RUNA_REF}" \
     && cp target/release/runa-mcp /build/runa-mcp-bin
 
 # ---------------------------------------------------------------------------
-# Stage 2: Final image
+# Stage 2: Download and verify Claude Code
+# ---------------------------------------------------------------------------
+FROM cgr.dev/chainguard/wolfi-base AS claude-downloader
+
+RUN attempt=1; \
+    until timeout 300 apk add --no-cache \
+            ca-certificates-bundle \
+            curl \
+            gpg \
+            gpg-agent \
+            jq; do \
+        if [ "${attempt}" -ge 3 ]; then \
+            echo "Failed to install Claude Code verification dependencies after ${attempt} attempts" >&2; \
+            exit 1; \
+        fi; \
+        attempt=$((attempt + 1)); \
+        echo "Retrying Claude Code verification dependency install: attempt ${attempt}/3" >&2; \
+        sleep 5; \
+    done
+
+ENV CLAUDE_CODE_VERSION=2.1.126
+ENV CLAUDE_CODE_RELEASE_KEY_FINGERPRINT=31DDDE24DDFAB679F42D7BD2BAA929FF1A7ECACE
+
+RUN timeout 900 sh -euxc '\
+        release_base="https://downloads.claude.ai/claude-code-releases/${CLAUDE_CODE_VERSION}"; \
+        case "$(apk --print-arch)" in \
+            x86_64) claude_platform="linux-x64" ;; \
+            aarch64) claude_platform="linux-arm64" ;; \
+            *) echo "Unsupported Claude Code architecture: $(apk --print-arch)" >&2; exit 1 ;; \
+        esac; \
+        export GNUPGHOME="$(mktemp -d)"; \
+        mkdir -p /usr/local/bin; \
+        echo "Downloading Claude Code signing key"; \
+        curl --retry 3 --retry-all-errors --connect-timeout 15 --max-time 120 \
+            -fsSLo /tmp/claude-code.asc \
+            https://downloads.claude.ai/keys/claude-code.asc; \
+        gpg --batch --import /tmp/claude-code.asc; \
+        actual_fingerprint="$(gpg --batch --with-colons --fingerprint security@anthropic.com \
+            | grep "^fpr:" \
+            | head -n 1 \
+            | cut -d: -f10)"; \
+        test "${actual_fingerprint}" = "${CLAUDE_CODE_RELEASE_KEY_FINGERPRINT}"; \
+        echo "Downloading Claude Code ${CLAUDE_CODE_VERSION} manifest"; \
+        curl --retry 3 --retry-all-errors --connect-timeout 15 --max-time 120 \
+            -fsSLo /tmp/manifest.json \
+            "${release_base}/manifest.json"; \
+        curl --retry 3 --retry-all-errors --connect-timeout 15 --max-time 120 \
+            -fsSLo /tmp/manifest.json.sig \
+            "${release_base}/manifest.json.sig"; \
+        gpg --batch --verify /tmp/manifest.json.sig /tmp/manifest.json; \
+        expected_checksum="$(jq -r ".platforms[\"${claude_platform}\"].checksum" /tmp/manifest.json)"; \
+        test -n "${expected_checksum}"; \
+        test "${expected_checksum}" != "null"; \
+        echo "Downloading Claude Code ${CLAUDE_CODE_VERSION} for ${claude_platform}"; \
+        curl --retry 3 --retry-all-errors --connect-timeout 15 --max-time 600 \
+            -C - \
+            -fsSLo /usr/local/bin/claude \
+            "${release_base}/${claude_platform}/claude"; \
+        echo "${expected_checksum}  /usr/local/bin/claude" | sha256sum -c -; \
+        chmod 0755 /usr/local/bin/claude; \
+        rm -rf "${GNUPGHOME}" /tmp/claude-code.asc /tmp/manifest.json /tmp/manifest.json.sig \
+    '
+
+# ---------------------------------------------------------------------------
+# Stage 3: Final image
 # ---------------------------------------------------------------------------
 FROM cgr.dev/chainguard/wolfi-base
 
@@ -49,13 +113,9 @@ RUN apk add --no-cache \
 # Wolfi minimal image does not include /usr/local/bin
 RUN mkdir -p /usr/local/bin
 
-# Claude Code — native installer (no Node.js required on glibc)
-# The installer symlinks ~/.local/bin/claude -> ~/.local/share/claude/versions/<ver>.
-# Copy the resolved binary (not the symlink) to a system-wide path so the
-# unprivileged agent user can access it after gosu privilege drop.
-RUN curl -fsSL https://claude.ai/install.sh | bash \
-    && cp -L /root/.local/bin/claude /usr/local/bin/claude \
-    && rm -rf /root/.local/share/claude /root/.local/bin/claude /root/.cache/claude
+# Claude Code from a pinned Anthropic release. The downloader stage verifies
+# the release manifest signature and binary checksum before this copy.
+COPY --from=claude-downloader /usr/local/bin/claude /usr/local/bin/claude
 
 # runa CLI and MCP server from builder stage
 COPY --from=runa-builder /build/runa-bin /usr/local/bin/runa

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ owns the entrypoint.
 source. Loads methodology manifests, validates artifacts, enforces dependency
 graphs.
 
-**Agent runtime:** [Claude Code](https://claude.ai/code) via the native
-installer. Authenticate headlessly by injecting `ANTHROPIC_API_KEY` as a
-credential in your agentd agent configuration.
+**Agent runtime:** [Claude Code](https://claude.ai/code), pinned to a verified
+Anthropic release binary. Authenticate headlessly by injecting
+`ANTHROPIC_API_KEY` as a credential in your agentd agent configuration.
 
 ## Building
 
@@ -35,6 +35,10 @@ To pin runa to a specific version or tag:
 ```bash
 podman build --build-arg RUNA_REF=v0.1.0 -t tesserine/base .
 ```
+
+Claude Code is intentionally pinned in the Dockerfile. Version bumps are manual
+build-substrate changes so the release manifest signature, binary checksum,
+image build, and runtime contract can be verified together.
 
 ## Using with agentd
 
@@ -67,9 +71,9 @@ agentd daemon --config /etc/agentd/agentd.toml
 
 Fork this repo and modify the Dockerfile. Common customizations:
 
-- **Different agent runtime:** Replace the Claude Code installer with Codex
-  (`npm i -g @openai/codex`), or any CLI that can receive prompts and produce
-  file changes.
+- **Different agent runtime:** Replace the Claude Code release binary with
+  Codex (`npm i -g @openai/codex`), or any CLI that can receive prompts and
+  produce file changes.
 - **Additional tools:** Add language runtimes, linters, or build tools your
   agents need.
 - **Different methodology:** The methodology is mounted read-only by agentd at


### PR DESCRIPTION
## Summary

- Replaces the opaque Claude Code latest installer path with a pinned Anthropic release binary.
- Verifies the release through Anthropic's signing key fingerprint, detached manifest signature, and manifest-derived SHA256 checksum.
- Keeps fresh builds bounded and operator-readable, including resumable binary downloads for slow links.

## Changes

- Adds a `claude-downloader` stage that installs only build-time verification dependencies, retries bounded package setup, and downloads Claude Code `2.1.126` from the versioned release substrate.
- Copies the verified `/usr/local/bin/claude` binary into the final image instead of running `claude install`.
- Updates README and CHANGELOG to document the pinned Claude Code release model and manual version bump policy.

## GitHub Issue(s)

Closes #5

## Test plan

- `git diff --check`
- Static contract check confirmed:
  - Dockerfile no longer references `https://claude.ai/install.sh`.
  - Dockerfile does not run `claude install`.
  - Dockerfile contains the pinned Claude version, release key fingerprint, detached manifest signature verification, manifest-derived checksum verification, timeout bounds, `gpg-agent`, and resumable `curl -C -` binary download.
- `podman build --target claude-downloader --tag localhost/tesserine/base-claude .`
  - Verified Anthropic release key fingerprint.
  - Verified detached `manifest.json.sig` signature.
  - Resumed the large Claude binary download after timeout.
  - Verified `/usr/local/bin/claude: OK` via SHA256.
- `podman build --tag localhost/tesserine/base .`
- `podman run --rm localhost/tesserine/base /bin/sh -lc 'test "$(command -v claude)" = /usr/local/bin/claude && claude --version | grep 2.1.126'`
- `podman run --rm localhost/tesserine/base /bin/sh -lc 'useradd -m agent && gosu agent /usr/local/bin/claude --version | grep 2.1.126'`
- `podman run --rm localhost/tesserine/base /bin/sh -lc 'for bin in /bin/sh git useradd gosu chown runa runa-mcp claude; do command -v "$bin"; done; runa --version; runa-mcp --help >/tmp/runa-mcp-help'`
