### PR TITLE
fix(image): expose base source labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Image builds now expose OCI and Tesserine labels for the base ref, runa ref,
+  and Claude Code version so deployment contents can be inspected without
+  entering a container.
+- README build guidance now requires deployment refs to use immutable tags or
+  full SHAs instead of mutable branch names such as `main`.
 - README agentd configuration example now uses the current `[[agents]]` schema
   with structured command argv.
 - Claude Code installation now uses a pinned Anthropic release binary verified

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache \
         glibc-dev \
         rust-1.89
 
-ARG RUNA_REF=v0.1.0
+ARG RUNA_REF=v0.1.2-rc.1
 RUN git clone --depth 1 --branch "${RUNA_REF}" \
         https://github.com/tesserine/runa.git /build/runa \
     && cd /build/runa \
@@ -53,7 +53,8 @@ RUN attempt=1; \
         sleep 5; \
     done
 
-ENV CLAUDE_CODE_VERSION=2.1.126
+ARG CLAUDE_CODE_VERSION=2.1.126
+ENV CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION}
 ENV CLAUDE_CODE_RELEASE_KEY_FINGERPRINT=31DDDE24DDFAB679F42D7BD2BAA929FF1A7ECACE
 
 RUN timeout 900 sh -euxc '\
@@ -101,6 +102,10 @@ RUN timeout 900 sh -euxc '\
 # ---------------------------------------------------------------------------
 FROM cgr.dev/chainguard/wolfi-base
 
+ARG BASE_REF=local
+ARG RUNA_REF=v0.1.2-rc.1
+ARG CLAUDE_CODE_VERSION=2.1.126
+
 # agentd runner contract
 RUN apk add --no-cache \
         bash \
@@ -120,6 +125,14 @@ COPY --from=claude-downloader /usr/local/bin/claude /usr/local/bin/claude
 # runa CLI and MCP server from builder stage
 COPY --from=runa-builder /build/runa-bin /usr/local/bin/runa
 COPY --from=runa-builder /build/runa-mcp-bin /usr/local/bin/runa-mcp
+
+LABEL org.opencontainers.image.title="tesserine/base" \
+      org.opencontainers.image.description="Reference container image for agentd agent sessions" \
+      org.opencontainers.image.source="https://github.com/tesserine/base" \
+      org.opencontainers.image.revision="${BASE_REF}" \
+      org.tesserine.base.ref="${BASE_REF}" \
+      org.tesserine.runa.ref="${RUNA_REF}" \
+      org.tesserine.claude-code.version="${CLAUDE_CODE_VERSION}"
 
 # The runner enters via /bin/sh -lc with a generated script that creates
 # the unprivileged user, clones the repo, and exec gosu's into the session

--- a/README.md
+++ b/README.md
@@ -26,19 +26,37 @@ Anthropic release binary. Authenticate headlessly by injecting
 
 ## Building
 
+Deployment builds must pin source material to immutable refs: tags or full
+commit SHAs. Do not build deployment images from `main`; mutable branch refs
+can reuse stale container build layers while the remote branch has moved.
+The shared release-candidate convention is defined in
+[commons RELEASE.md](https://github.com/tesserine/commons/blob/main/RELEASE.md).
+
 ```bash
-podman build -t tesserine/base .
+podman build \
+  --build-arg BASE_REF=v0.1.2-rc.1 \
+  --build-arg RUNA_REF=v0.1.2-rc.1 \
+  -t tesserine/base:v0.1.2-rc.1 .
 ```
 
-To pin runa to a specific version or tag:
+For local development, the defaults are usable, but they intentionally label
+the base image ref as `local`:
 
 ```bash
-podman build --build-arg RUNA_REF=v0.1.0 -t tesserine/base .
+podman build -t tesserine/base:local .
+```
+
+Inspect the image labels to confirm what was built:
+
+```bash
+podman inspect tesserine/base:v0.1.2-rc.1 | jq '.[0].Config.Labels'
 ```
 
 Claude Code is intentionally pinned in the Dockerfile. Version bumps are manual
 build-substrate changes so the release manifest signature, binary checksum,
-image build, and runtime contract can be verified together.
+image build, and runtime contract can be verified together. The built image
+exposes `org.tesserine.base.ref`, `org.tesserine.runa.ref`, and
+`org.tesserine.claude-code.version` labels for deployment inspection.
 
 ## Using with agentd
 


### PR DESCRIPTION
## Summary

- exposes base, runa, Claude Code, and OCI source labels in the base image
- defaults RUNA_REF to v0.1.2-rc.1 for the Phase E retest path
- documents immutable deployment refs and image-label inspection

Refs tesserine/ops#14.

## Verification

- git diff --check
- podman build --build-arg BASE_REF=issue-14-verify --build-arg RUNA_REF=v0.1.2-rc.1 -t localhost/tesserine-base:issue-14-verify .
- podman inspect localhost/tesserine-base:issue-14-verify | jq labels
- podman run --rm --entrypoint /usr/local/bin/runa localhost/tesserine-base:issue-14-verify --version