### PR TITLE
fix(release): pin RUNA_REF to stable runa v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release ceremony tooling now verifies the base changelog, Dockerfile label
   surface, tag-time image identity, and GitHub Release publication path.
 
+### Changed
+
+- `Dockerfile` `ARG RUNA_REF` defaults updated to `v0.1.2` (the published
+  stable runa release) on both the builder-stage and final-image label lines.
+  `README.md` build examples updated to reference current stable component
+  tags.
+- `RELEASING.md` documents the `RUNA_REF` dependency on a published runa tag,
+  with operator guidance for the cut sequence when updating `RUNA_REF`.
+
 ### Fixed
 
 - GitHub Release publication now restores annotated tag refs after checkout and

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache \
         glibc-dev \
         rust-1.89
 
-ARG RUNA_REF=v0.1.2-rc.1
+ARG RUNA_REF=v0.1.2
 COPY scripts/checkout-runa-ref /usr/local/bin/checkout-runa-ref
 RUN checkout-runa-ref checkout "${RUNA_REF}" /build/runa \
     && cd /build/runa \
@@ -103,7 +103,7 @@ RUN timeout 900 sh -euxc '\
 FROM cgr.dev/chainguard/wolfi-base
 
 ARG BASE_REF=local
-ARG RUNA_REF=v0.1.2-rc.1
+ARG RUNA_REF=v0.1.2
 ARG CLAUDE_CODE_VERSION=2.1.126
 
 # agentd runner contract

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The shared release-candidate convention is defined in
 
 ```bash
 podman build \
-  --build-arg BASE_REF=v0.1.2-rc.1 \
-  --build-arg RUNA_REF=v0.1.2-rc.1 \
-  -t tesserine/base:v0.1.2-rc.1 .
+  --build-arg BASE_REF=v0.1.1 \
+  --build-arg RUNA_REF=v0.1.2 \
+  -t tesserine/base:v0.1.1 .
 ```
 
 For local development, the defaults are usable, but they intentionally label
@@ -49,7 +49,7 @@ podman build -t tesserine/base:local .
 Inspect the image labels to confirm what was built:
 
 ```bash
-podman inspect tesserine/base:v0.1.2-rc.1 | jq '.[0].Config.Labels'
+podman inspect tesserine/base:v0.1.1 | jq '.[0].Config.Labels'
 ```
 
 Claude Code is intentionally pinned in the Dockerfile. Version bumps are manual

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,6 +26,28 @@ The runa ref must be an immutable tag or full commit SHA. base verifies that
 the ref is present and immutable-shaped; ecosystem verification owns proving
 that the runa ref matches the release manifest.
 
+## Dependencies
+
+base builds its container image from the runa workspace, pinned by the
+`RUNA_REF` argument defaulted in `Dockerfile` (two `ARG RUNA_REF=` lines:
+one for the runa builder stage, one for the final image's label surface).
+The release workflow's container build step fails immediately if `RUNA_REF`
+points at a git ref that does not exist in the runa repository.
+
+Before cutting base:
+
+- Verify the current `Dockerfile` `ARG RUNA_REF=` value resolves to a
+  published runa tag. Run `git ls-remote --tags
+  https://github.com/tesserine/runa.git "refs/tags/$RUNA_REF"` (or check via
+  the [runa releases page](https://github.com/tesserine/runa/releases)).
+- If updating `RUNA_REF` as part of preparing the base cut (typically to
+  point at a newer runa release), publish the new runa tag first. Cutting
+  base before the referenced runa tag exists will fail the container build
+  step of the release workflow, leaving an orphaned base tag and no
+  published GitHub Release.
+- Update both `ARG RUNA_REF=` occurrences in `Dockerfile` together. The
+  builder-stage value and final-image label value must match.
+
 ## Pre-Release Gate
 
 A releasable commit is on `main`, up to date with `origin/main`, and has a


### PR DESCRIPTION
## Summary

Fix the substrate defect that caused the v0.1.1 cut to fail. Dockerfile's `ARG RUNA_REF=` defaults pointed at `v0.1.2-rc.1`, a tag deleted during parking-cleanup. Container build step couldn't resolve the ref; workflow failed; no Release published. Cleanup of the false-start cut already done on main (commit 4e45954 reverting the chore release commit, v0.1.1 tag deleted from origin).

## Key changes

- `Dockerfile`: both `ARG RUNA_REF=` occurrences updated to `v0.1.2` (the published stable runa release cut today)
- `README.md`: build examples reference current stable component tags (v0.1.1 base + v0.1.2 runa)
- `RELEASING.md`: new Dependencies section documenting that base depends on a published runa tag via `RUNA_REF`, with operator guidance for cut sequencing
- `CHANGELOG.md`: Changed entries under [Unreleased] documenting both substrate updates

## Why the RELEASING.md update

The discoverability test: anyone preparing a base cut reads RELEASING.md. The Dependencies section sits right before the Pre-Release Gate, so the dependency check is captured in the canonical release procedure. Future base cuts will see (and execute) the RUNA_REF verification step before firing release-cut.

## Verification

- `./scripts/release-check metadata`: exit 0
- `./scripts/test-release-check`: passes
- Dockerfile syntax: valid
- No remaining `v0.1.2-rc.1` references in repo

## Next

Merge → re-cut base v0.1.1 → continue parking sequence (commons manifest + commons cut).