### PR TITLE
fix(image): include SSH client capability in reference session image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reference session images now include an OpenSSH client so Git SSH clone and
+  push transport can invoke `ssh` inside agent sessions.
+
 ## [0.1.1] — 2026-05-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 #   useradd    — unprivileged user creation (from shadow)
 #   gosu       — privilege drop after setup
 #   git        — repository cloning
+#   ssh        — Git SSH clone and push transport (from openssh-client)
 #   chown      — home directory ownership (from coreutils)
 #
 # Ships with:
@@ -113,6 +114,7 @@ RUN apk add --no-cache \
         curl \
         git \
         gosu \
+        openssh-client \
         shadow
 
 # Wolfi minimal image does not include /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ and a working agent runtime.
 purpose-built for containers.
 
 **agentd contract:** The runner expects the image to provide `/bin/sh`, `git`,
-`useradd`, `gosu`, and `chown`. These are installed as Wolfi packages. The
-runner enters through `/bin/sh -lc` with a generated script that creates an
+`ssh`, `useradd`, `gosu`, and `chown`. These are installed as Wolfi packages.
+The runner enters through `/bin/sh -lc` with a generated script that creates an
 unprivileged user, clones the target repository, and drops privileges before
 executing the session command. The image sets no ENTRYPOINT or CMD — agentd
 owns the entrypoint.
@@ -112,9 +112,10 @@ The agentd runner makes these assumptions about the image:
 | `useradd` | Creates the unprivileged session user | `shadow` |
 | `gosu` | Drops root privileges permanently before session command | `gosu` |
 | `git` | Clones the target repository into the workspace | `git` |
+| `ssh` | Enables Git SSH clone and push transport | `openssh-client` |
 | `chown` | Transfers home directory ownership to the session user | `coreutils` |
 
-If you build a custom image, these five capabilities must be present.
+If you build a custom image, these six capabilities must be present.
 
 ## License
 

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -359,6 +359,40 @@ inspect_label() {
     "$runtime" inspect --format "{{ index .Config.Labels \"$label\" }}" "$image"
 }
 
+run_container_shell() {
+    local runtime="$1"
+    local image="$2"
+    local command="$3"
+
+    "$runtime" run --rm "$image" sh -lc "$command"
+}
+
+check_container_ssh_client() {
+    local runtime="$1"
+    local image="$2"
+    local git_ssh_probe
+
+    run_container_shell "$runtime" "$image" 'command -v ssh >/dev/null && ssh -V 2>&1 | grep -Eq "^OpenSSH_"' \
+        || die "container image cannot execute ssh -V"
+
+    git_ssh_probe='
+output="$(GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=1" git ls-remote ssh://git@127.0.0.1:1/tesserine/base 2>&1)"
+status="$?"
+if [ "$status" -eq 0 ]; then
+    exit 0
+fi
+case "$output" in
+    *"cannot run ssh"*|*"No such file or directory"*|*"ssh: not found"*)
+        printf "%s\n" "$output" >&2
+        exit 1
+        ;;
+esac
+printf "%s\n" "$output" | grep -Eq "ssh: connect to host 127[.]0[.]0[.]1 port 1|Connection refused|Connection timed out|Network is unreachable|No route to host"
+'
+    run_container_shell "$runtime" "$image" "$git_ssh_probe" \
+        || die "container image cannot invoke ssh through Git SSH transport"
+}
+
 check_container_image() {
     local tag="$1"
     local image="$2"
@@ -375,6 +409,7 @@ check_container_image() {
         || die "container image label org.tesserine.base.ref is '$base_ref', expected '$tag'"
     [[ -n "$runa_ref" ]] || die "container image label org.tesserine.runa.ref is missing"
     check_immutable_ref_shape "container image label org.tesserine.runa.ref" "$runa_ref"
+    check_container_ssh_client "$runtime" "$image"
 }
 
 emit_notes() {

--- a/scripts/test-release-check
+++ b/scripts/test-release-check
@@ -426,6 +426,9 @@ case "$1" in
       *) printf '\n' ;;
     esac
     ;;
+  run)
+    exit 0
+    ;;
   *)
     echo "unexpected fake runtime command: $*" >&2
     exit 64
@@ -434,6 +437,110 @@ esac
 EOF
     chmod +x "$root/fake-runtime"
     assert_success "${FUNCNAME[0]}" run_check_with_runtime "$root" "$root/fake-runtime" release v1.2.3 --container-image localhost/base:v1.2.3
+}
+
+release_checks_container_ssh_capability() {
+    local root
+    root="$(new_fixture release-container-ssh 1.2.3)"
+    cat >"$root/fake-runtime" <<EOF
+#!/usr/bin/env sh
+set -eu
+case "\$1" in
+  inspect)
+    case "\$3" in
+      *org.opencontainers.image.revision*) printf 'v1.2.3\n' ;;
+      *org.tesserine.base.ref*) printf 'v1.2.3\n' ;;
+      *org.tesserine.runa.ref*) printf 'v0.1.2-rc.1\n' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  run)
+    shift
+    printf '%s\n' "\$*" >>"$root/runtime.log"
+    case "\$*" in
+      *"ssh -V"*) exit 0 ;;
+      *"git ls-remote ssh://git@127.0.0.1:1/tesserine/base"*) exit 0 ;;
+      *) echo "unexpected fake runtime run command: \$*" >&2; exit 64 ;;
+    esac
+    ;;
+  *)
+    echo "unexpected fake runtime command: \$*" >&2
+    exit 64
+    ;;
+esac
+EOF
+    chmod +x "$root/fake-runtime"
+    assert_success "${FUNCNAME[0]}" run_check_with_runtime "$root" "$root/fake-runtime" release v1.2.3 --container-image localhost/base:v1.2.3
+    grep -Fq 'ssh -V' "$root/runtime.log" \
+        || fail "${FUNCNAME[0]} runs ssh -V"
+    grep -Fq 'git ls-remote ssh://git@127.0.0.1:1/tesserine/base' "$root/runtime.log" \
+        || fail "${FUNCNAME[0]} runs Git SSH transport smoke check"
+}
+
+release_rejects_container_images_without_executable_ssh() {
+    local root
+    root="$(new_fixture release-container-no-ssh 1.2.3)"
+    cat >"$root/fake-runtime" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+case "$1" in
+  inspect)
+    case "$3" in
+      *org.opencontainers.image.revision*) printf 'v1.2.3\n' ;;
+      *org.tesserine.base.ref*) printf 'v1.2.3\n' ;;
+      *org.tesserine.runa.ref*) printf 'v0.1.2-rc.1\n' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  run)
+    shift
+    case "$*" in
+      *"ssh -V"*) exit 127 ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+EOF
+    chmod +x "$root/fake-runtime"
+    assert_failure_contains "${FUNCNAME[0]}" "cannot execute ssh -V" run_check_with_runtime "$root" "$root/fake-runtime" release v1.2.3 --container-image localhost/base:v1.2.3
+}
+
+release_rejects_container_images_without_git_ssh_transport() {
+    local root
+    root="$(new_fixture release-container-no-git-ssh 1.2.3)"
+    cat >"$root/fake-runtime" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+case "$1" in
+  inspect)
+    case "$3" in
+      *org.opencontainers.image.revision*) printf 'v1.2.3\n' ;;
+      *org.tesserine.base.ref*) printf 'v1.2.3\n' ;;
+      *org.tesserine.runa.ref*) printf 'v0.1.2-rc.1\n' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  run)
+    shift
+    case "$*" in
+      *"ssh -V"*) exit 0 ;;
+      *"git ls-remote ssh://git@127.0.0.1:1/tesserine/base"*)
+        echo 'fatal: cannot run ssh: No such file or directory' >&2
+        exit 128
+        ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+EOF
+    chmod +x "$root/fake-runtime"
+    assert_failure_contains "${FUNCNAME[0]}" "cannot invoke ssh through Git SSH transport" run_check_with_runtime "$root" "$root/fake-runtime" release v1.2.3 --container-image localhost/base:v1.2.3
 }
 
 release_rejects_container_label_mismatches() {
@@ -634,6 +741,9 @@ release_validation_rejects_zero_rc_ordinal
 release_rejects_missing_matching_changelog_heading
 release_heading_lookup_uses_literal_matching
 release_checks_container_label_identity
+release_checks_container_ssh_capability
+release_rejects_container_images_without_executable_ssh
+release_rejects_container_images_without_git_ssh_transport
 release_rejects_container_label_mismatches
 release_rejects_empty_container_image_values
 release_workflow_uses_broad_tag_filter_with_early_validation


### PR DESCRIPTION
## Summary

- Adds `openssh-client` to the final reference session image so Git SSH clone and push flows can invoke `ssh`.
- Documents SSH client availability in the image contract.
- Extends release artifact validation with runtime `ssh -V` and Git SSH transport checks.

## Changes

- Installs Wolfi `openssh-client` in the Dockerfile final stage.
- Updates README contract docs and the unreleased changelog.
- Adds release-check container runtime probes and regression coverage for missing SSH behavior.

## GitHub Issue(s)

Closes #21

## Test plan

- `bash -n scripts/release-check scripts/test-release-check`
- `./scripts/release-check metadata`
- `./scripts/test-release-check`
- `podman build --build-arg BASE_REF=v0.1.1 --tag localhost/base:ssh-client .`
- `./scripts/release-check release v0.1.1 --container-image localhost/base:ssh-client`
- `podman run --rm localhost/base:ssh-client sh -lc 'command -v ssh && ssh -V'`
- Git SSH transport smoke check against `ssh://git@127.0.0.1:1/tesserine/base`, expecting SSH to run before localhost connection refusal.
