### PR TITLE
docs(release): tooling ownership, test entry points, Claude Code bump procedure, change loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RELEASING.md` gains Release Tooling Ownership (the per-repo ownership of
+  the structurally similar release scripts across the ecosystem, and that
+  no repo is the tooling upstream), Testing the Release Tooling
+  (`test-release-check`, `verify-release-adoption.sh` entry points), and
+  Updating the Pinned Claude Code (version bump and signing-key-fingerprint
+  rotation procedure).
+- `scripts/release-check` carries a provenance header naming the commons
+  convention as canonical and its sibling implementations as independently
+  owned.
+
+
 ### Fixed
 
 - Reference session images now include an OpenSSH client so Git SSH clone and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`test-release-check`, `verify-release-adoption.sh` entry points), and
   Updating the Pinned Claude Code (version bump and signing-key-fingerprint
   rotation procedure).
+- README Contributing section: the image/script change loop and its local
+  verification commands.
 - `scripts/release-check` carries a provenance header naming the commons
   convention as canonical and its sibling implementations as independently
   owned.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ Fork this repo and modify the Dockerfile. Common customizations:
   runtime, not baked into the image. No image change needed to switch
   methodologies.
 
+## Contributing
+
+The change loop for the image and its scripts:
+
+1. Edit `Dockerfile` (preserve its self-documenting header and per-decision
+   rationale comments — they are the contract) or the release scripts.
+2. Verify locally:
+
+   ```sh
+   podman build --tag localhost/tesserine/base:dev .
+   ./scripts/test-release-check          # release-check behavior
+   ./scripts/verify-release-adoption.sh  # end-to-end ceremony self-test
+   ```
+
+3. Record the change in `CHANGELOG.md` under `[Unreleased]`.
+
+Version pins (`RUNA_REF`, `CLAUDE_CODE_VERSION`, the signing-key
+fingerprint) have their own procedures in [RELEASING.md](RELEASING.md).
+
 ## Container Contract
 
 The agentd runner makes these assumptions about the image:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,6 +48,60 @@ Before cutting base:
 - Update both `ARG RUNA_REF=` occurrences in `Dockerfile` together. The
   builder-stage value and final-image label value must match.
 
+## Release Tooling Ownership
+
+`scripts/release-check`, `scripts/release-cut`, and
+`scripts/checkout-runa-ref` are **base-owned**. They implement the shared
+release ceremony convention — canonical in
+[commons RELEASE.md](https://github.com/tesserine/commons/blob/main/RELEASE.md)
+and ADR-0006/0011/0012 — against base's own release surface (container image
+labels, runa-ref pinning).
+
+agentd, runa, commons, and groundwork carry structurally similar
+`release-check`/`release-cut` scripts. They share ancestry from the
+ecosystem-wide ceremony adoption
+([commons#21](https://github.com/tesserine/commons/issues/21), which
+required each release-surface repo to acquire its **own** tooling), but they
+are independently owned: no repo is the tooling upstream, and a fix in one
+repo's script does not propagate to the others. A ceremony-level behavior
+change lands in the commons convention first; each repo then applies it to
+its own implementation and tests.
+
+## Testing the Release Tooling
+
+Run the tooling's own tests after changing any release script:
+
+```sh
+./scripts/test-release-check          # fixture-based checks of release-check behavior
+./scripts/verify-release-adoption.sh  # end-to-end: release-cut + release-check in a scratch repo
+```
+
+`verify-release-adoption.sh` seeds a throwaway git repo with base's release
+tooling, cuts a stable and an RC release there, and asserts the full
+ceremony state (changelog roll, annotated tag at the release commit, clean
+tree, pushed refs, passing release-check). It verifies base's own ceremony
+adoption — it does not police other repos.
+
+## Updating the Pinned Claude Code
+
+The image pins Claude Code by version, release-key fingerprint, and
+per-platform sha256 (`Dockerfile`, the `CLAUDE_CODE_VERSION` block). To bump
+the version:
+
+1. Update `ARG CLAUDE_CODE_VERSION=` in `Dockerfile`.
+2. Build; the build fails unless the new release's GPG-signed manifest
+   verifies against the pinned fingerprint and the binary matches the
+   manifest checksum.
+3. Record the bump in `CHANGELOG.md` under `[Unreleased]`.
+
+If the build fails on the fingerprint comparison, Anthropic has rotated the
+release signing key. Do not copy the new fingerprint from the failing
+build. Obtain it from a trusted Anthropic channel (the published
+`claude-code.asc` over HTTPS cross-checked against Anthropic's
+documentation), verify it out-of-band, then update
+`ENV CLAUDE_CODE_RELEASE_KEY_FINGERPRINT=` and record the rotation and its
+verification source in `CHANGELOG.md`.
+
 ## Pre-Release Gate
 
 A releasable commit is on `main`, up to date with `origin/main`, and has a

--- a/scripts/release-check
+++ b/scripts/release-check
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# base-owned implementation of the Tesserine release ceremony.
+# Convention canonical: commons RELEASE.md + ADR-0006/0011/0012
+# (https://github.com/tesserine/commons). This script verifies base's own
+# release surface. Sibling implementations in agentd, base, commons, runa,
+# and groundwork share ancestry (commons#21) but are independently owned:
+# no repo is the tooling upstream and fixes do not propagate automatically.
+
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 # shellcheck disable=SC2034


### PR DESCRIPTION
Part of the ecosystem-wide documentation coherence pass (refs tesserine/commons#5).

## What this does

- **RELEASING.md § Release Tooling Ownership** — records the verified ownership model: the release-check/release-cut scripts across the ecosystem share ancestry from the ceremony adoption (tesserine/commons#21) but are deliberately per-repo-owned; no repo is the tooling upstream and fixes do not propagate. `verify-release-adoption.sh` is documented as a self-test of base's own ceremony, not a policer of other repos.
- **Testing the Release Tooling** — `test-release-check` and `verify-release-adoption.sh` entry points, previously documented nowhere.
- **Updating the Pinned Claude Code** — version bump and signing-key fingerprint rotation procedure (with out-of-band verification on rotation).
- README Contributing section: the image/script change loop. `release-check` provenance header.

## Verification

- `./scripts/test-release-check` and `./scripts/verify-release-adoption.sh` both pass with the header in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
