### PR TITLE
docs(readme): lead with the supply-chain verification story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- README hero rewritten for the ecosystem README pass: leads with the
+  supply-chain verification story (Wolfi base, pinned runa ref,
+  GPG-and-checksum-verified agent runtime, fail-closed build) and base's
+  place in the Tesserine stack.
+
 ### Added
 
 - `RELEASING.md` gains Release Tooling Ownership (the per-repo ownership of

--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # base
 
+**The supply-chain-verified substrate agents run on.**
+
 Reference container image for [agentd](https://github.com/tesserine/agentd)
-agent sessions. Wolfi-based, minimal, ships with the agentd runner contract
-and a working agent runtime.
+agent sessions. An autonomous agent's runtime is exactly the kind of binary
+that deserves paranoia, so this image earns trust the checkable way: a
+minimal, zero-CVE-target [Wolfi](https://wolfi.dev) OS layer; the
+[runa](https://github.com/tesserine/runa) runtime built from a pinned,
+immutable source ref; and the agent runtime installed only after its release
+manifest verifies against a pinned GPG fingerprint and the binary matches the
+manifest's sha256 — a build that fails closed on any mismatch. The
+[Dockerfile](Dockerfile) documents every one of those decisions inline; it is
+the ecosystem's exemplar for self-documenting infrastructure.
+
+base is the **Run** tier's substrate in the
+[Tesserine](https://github.com/tesserine) stack (ecosystem map:
+[commons SOURCE-OF-TRUTH.md](https://github.com/tesserine/commons/blob/main/SOURCE-OF-TRUTH.md)).
 
 ## What's Inside
 


### PR DESCRIPTION
Part of the README excellence pass (refs tesserine/commons#5): rewrite the nine front doors — org profile + eight repo READMEs — as one cohesive narrative in a grounded-visionary voice, every claim traceable to a contract, architecture doc, test, or runnable example.

Hero leads with the verified supply chain: pinned runa ref, GPG-fingerprint + sha256-verified agent runtime, fail-closed build, self-documenting Dockerfile.

Verification for the whole pass: SOURCE-OF-TRUTH reachable from all nine pages; no page asserts the exploratory concept draft as fact; agentd's test-enforced phrases and groundwork's forbidden-phrase gates verified; example-hello's canonical-request contract intact; all relative links resolve; suites green (agentd 24/24 workspace_contract, runa 14/14 workspace_contract, groundwork 299+36, gazette 11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)